### PR TITLE
Update parser to fix breaking change from sphinx 6.0

### DIFF
--- a/dagstd/sphinx/parser.py
+++ b/dagstd/sphinx/parser.py
@@ -1,5 +1,6 @@
 from inspect import signature
 from typing import Any
+from docutils import nodes
 
 from sphinx.domains.python import PyFunction
 from sphinx.ext.autodoc import FunctionDocumenter
@@ -52,7 +53,7 @@ class OpDirective(PyFunction):
 
     # pylint: disable-next=unused-argument
     def get_signature_prefix(self, sig):
-        return self.env.config.dagster_op_prefix
+        return return [nodes.Text(self.env.config.dagster_op_prefix)]
 
 
 def setup(app):


### PR DESCRIPTION
Clones this PR to Celery: [https://github.com/celery/celery/pull/7978/files](https://github.com/celery/celery/pull/7978/files)

Brings the parser up to functional with changes to Sphinx 6.0.0 and greater